### PR TITLE
adding ach samples to Direct API repository

### DIFF
--- a/php/account_updater/get_account_updater.php
+++ b/php/account_updater/get_account_updater.php
@@ -1,0 +1,148 @@
+<?php
+
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Sage Payment Solutions
+Contact: sdksupport@sage.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
+     
+    require("shared.php");
+    
+	// the nonce can be any unique identifier -- guids and timestamps work well
+	$nonce = uniqid();
+	
+	// a standard unix timestamp. a request must be received within 60s
+    // of its timestamp header.
+    $timestamp = (string)time();
+    
+	// Note that the verb here is differe from a Sale or Authorization. They use
+	// POST, with this request we will use GET.
+	$verb = "GET";
+	
+	// replace value after "startDate=" with the 1st date in the range.
+	// replace value after "endDate=" with the last date in the range.
+	// details for this request can be found at https://developer.sagepayments.com/account-updater/apis/get/accountupdater
+	// >>>please note the URL and query are case sensetive also the query mush include dashes and not slashes<<<
+    $url = "https://api-cert.sagepayments.com/accountupdater/v1/accountupdater?startDate=2017-10-10&endDate=2017-10-23";
+	
+	
+	
+	// the request is authorized via an HMAC header that we generate by
+    // concatenating certain info, and then hashing it using our client key
+	// Note that there is no $payload. There is no request body when performing
+	// this type of request.
+	$toBeHashed = $verb . $url . $merchantCredentials["ID"] . $nonce . $timestamp;
+    $hmac = getHmac($toBeHashed, $developerCredentials["KEY"]);
+    
+    // ok, let's make the request! cURL is always an option, of course,
+    // but i find that file_get_contents is a bit more intuitive.
+	// Note there is no content header. Since there is no payload this is absent.
+	$config = [
+        "http" => [
+            "header" => [
+                "clientId: " . $developerCredentials["ID"],
+                "merchantId: " . $merchantCredentials["ID"],
+                "merchantKey: " . $merchantCredentials["KEY"],
+                "nonce: " . $nonce,
+                "timestamp: " . $timestamp,
+                "authorization: " . $hmac,
+                "content-type: application/json",
+            ],
+            "method" => $verb,
+            "ignore_errors" => true // exposes response body on 4XX errors
+        ]
+    ];
+    
+	// Process request and perform error checking.
+	try {
+              $context = stream_context_create($config);
+			  $result = file_get_contents($url, false, $context);
+              $response = json_decode($result);
+			  $httpcode = http_response_code();
+
+			  
+			// file_get_contents will return a true or false based on the success or failure of the connection  
+            if($result == FALSE) 
+            { 
+                debug_to_console( "file_get_contents: False" );
+				echo '<pre>';
+				print_r('HTTP Code: ' . $httpcode);
+				echo '</pre>';
+				echo '<pre>';
+				echo 'Error: Failed to read page'; 
+				echo '</pre>';
+				exit();
+			} 
+            else 
+            {
+                // check to see if the results are empty
+				if (empty($result)){
+					debug_to_console( "Error: Empty Result" );
+					echo '<pre>';
+					print_r('HTTP Code: ' . $httpcode);
+					echo '</pre>';
+					echo '<pre>';
+                    echo 'Error Empty Result';
+					echo '</pre>';
+                    print_r(json_encode($result));
+					exit();
+                }
+                else 
+                {
+                    // If the "response" key is present then the transaction either approved or declined. Otherwise
+					// the result will contain a code with an error
+					if(array_key_exists('VaultResults', $response)) 
+                    {
+                        // Successful request
+						debug_to_console( "file_get_contents: True" );
+						echo '<pre>';
+						print_r('HTTP Code: ' . $httpcode);
+						echo '</pre>';
+						echo '<pre>';
+                        echo 'Request Successfully Submitted';
+						echo '</pre>';
+					}
+                    else 
+                    {
+                        // failed request
+						debug_to_console( "Error response from server!" );
+						echo '<pre>';
+						print_r('HTTP Code: ' . $httpcode);
+						echo '</pre>';
+						echo '<pre>';
+                        echo 'Error response from the server!';
+						echo '</pre>';
+                        echo '<pre>';
+						print 'Error Code: '. $response->{'code'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Message: '. $response->{'message'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Information: '. $response->{'info'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Details: '. $response->{'detail'};
+						echo '</pre>';
+					}
+        
+                    // print the results
+					echo '<pre>';
+                    print_r($response);
+                    echo '</pre>';
+                }
+            }
+            
+        }
+		
+		// Catch and print any exceptions
+		catch (Exception $ex) {
+            debug_to_console( $ex );
+			print_r($ex);
+			exit();
+        }
+?>

--- a/php/account_updater/shared.php
+++ b/php/account_updater/shared.php
@@ -1,0 +1,63 @@
+<?php
+
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Sage Payment Solutions
+Contact: sdksupport@sage.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
+
+    // You (or your client's) merchant credentials.
+    // grab a test account from us for development!
+	// If you would like a merchant test account, please
+	// email us at sdksupport@sage.com, otherwise
+	// you are welcome to test with the credentials below.
+    $merchantCredentials = [
+       "ID" => "173859436515",
+       "KEY" => "P1J2V8P2Q3D8"
+    ];
+	
+    
+	// Your application's credentials. In order to obtain
+	// your individual developer credentials you must
+	// register with the developer portal at https://developer.sagepayments.com
+	// and setup an app under "My Apps".
+    $developerCredentials = [
+       "ID" => "W8yvKQ5XbvAn7dUDJeAnaWCEwA4yXEgd",
+       "KEY" => "iLzODV5AUsCGWGkr"
+    ];
+	
+	
+
+	
+	function getHmac($toBeHashed, $privateKey){
+       
+        $hmac = hash_hmac(
+            "sha512", // use the SHA-512 algorithm...
+            $toBeHashed, // ... to hash the combined string...
+            $privateKey, // .. using your private dev key to sign it.
+            true // (php returns hexits by default; override this)
+        );
+        // convert to base-64 for transport
+        $hmac_b64 = base64_encode($hmac);
+        return $hmac_b64;
+    }
+	
+	// This function allows you to easily print data to the console
+	// for debugging. 
+	// !!!!!!!!!!!!!!!!!!!!!!!!  IMPORTANT NOTE  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+	// Please make sure you are not printing PCI-
+	// sensitive data to the console when moving to production.
+	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+	function debug_to_console( $data ) {
+		$output = $data;
+		if ( is_array( $output ) )
+			$output = implode( ',', $output);
+
+		echo "<script>console.log( 'Debug Objects: " . $output . "' );</script>";
+	}
+	
+?>

--- a/php/ach/ach_credit.php
+++ b/php/ach/ach_credit.php
@@ -1,0 +1,199 @@
+<?php
+
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Sage Payment Solutions
+Contact: sdksupport@sage.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
+    
+    require("shared.php");
+	
+    // the nonce can be any unique identifier -- guids and timestamps work well
+    $nonce = uniqid();
+    
+    // a standard unix timestamp. a request must be received within 60s
+    // of its timestamp header.
+    $timestamp = (string)time();
+    
+    // setting up the request data itself
+    $verb = "POST";
+    $url = "https://api-cert.sagepayments.com/ach/v1/credits";
+	$requestData = [
+        // this is a pretty minimalistic example...
+        // complete reference material is available on the dev portal.
+		// at https://developer.sagepayments.com/ach/apis
+        "orderNumber" => "Invoice " . rand(0, 1000),
+		"secCode" => "PPD",
+        "amounts" => [
+			"total" => "10.01"
+        ],
+        "account" => [
+			"type" => "Checking", 
+            "routingNumber" => "056008849",
+			"accountNumber" => "12345678901234"
+        ],
+		"billing" => [
+			"name" => [
+				"first" => "John", 
+				"middle" => "",
+				"last" => "Simpson",
+				"suffix" => "Dr."
+			], 
+            "address" => "123 Main St",
+			"city" => "Savannah",
+			"state" => "GA",
+			"postalCode" => "31405",
+			"country" => "US"
+        ],
+		"addenda" => "Widgets",
+		"vault" => [
+			"operation" => "Create"
+        ],
+		"memo" => "Test ACH Credit in Dev Portal"
+    ];
+    // convert to json for transport
+    $payload = json_encode($requestData);
+	
+    // the request is authorized via an HMAC header that we generate by
+    // concatenating certain info, and then hashing it using our client key
+    $toBeHashed = $verb . $url . $payload . $merchantCredentials["ID"] . $nonce . $timestamp;
+    $hmac = getHmac($toBeHashed, $developerCredentials["KEY"]);
+	
+    // ok, let's make the request! cURL is always an option, of course,
+    // but i find that file_get_contents is a bit more intuitive.
+    $config = [
+        "http" => [
+            "header" => [
+                "clientId: " . $developerCredentials["ID"],
+                "merchantId: " . $merchantCredentials["ID"],
+                "merchantKey: " . $merchantCredentials["KEY"],
+                "nonce: " . $nonce,
+                "timestamp: " . $timestamp,
+                "authorization: " . $hmac,
+                "content-type: application/json",
+            ],
+            "method" => $verb,
+            "content" => $payload,
+            "ignore_errors" => true // exposes response body on 4XX errors
+        ]
+    ];
+	
+	// Process request and perform error checking.
+	try {
+              $context = stream_context_create($config);
+			  $result = file_get_contents($url, false, $context);
+              $response = json_decode($result);
+			  $httpcode = http_response_code();
+
+			  
+			// file_get_contents will return a true or false based on the success or failure of the connection  
+            if($result == FALSE) 
+            { 
+                debug_to_console( "file_get_contents: False" );
+				echo '<pre>';
+				print_r('HTTP Code: ' . $httpcode);
+				echo '</pre>';
+				echo '<pre>';
+				echo 'Error: Failed to read page'; 
+				echo '</pre>';
+				exit();
+			} 
+            else 
+            {
+                // check to see if the results are empty
+				if (empty($result)){
+					debug_to_console( "Error: Empty Result" );
+					echo '<pre>';
+					print_r('HTTP Code: ' . $httpcode);
+					echo '</pre>';
+					echo '<pre>';
+                    echo 'Error Empty Result';
+					echo '</pre>';
+                    print_r(json_encode($result));
+					exit();
+                }
+                else 
+                {
+                    // If the "status" key is present then the transaction either approved or declined. Otherwise
+					// the result will contain a code with an error
+					if(array_key_exists('status', $response)) 
+                    {
+                        // Successful request
+						debug_to_console( "file_get_contents: True" );
+						echo '<pre>';
+						print_r('HTTP Code: ' . $httpcode);
+						echo '</pre>';
+						echo '<pre>';
+                        echo 'Request Successfully Submitted';
+						echo '</pre>';
+						echo '<pre>';
+						print 'Status: '. $response->{'status'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Reference: '. $response->{'reference'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Message: '. $response->{'message'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Order Number: '. $response->{'orderNumber'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Vault Response Status: '. $response->{'vaultResponse'}->{'status'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Vault Response Message: '. $response->{'vaultResponse'}->{'message'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Vault Token: '. $response->{'vaultResponse'}->{'data'};
+						echo '</pre>';
+						echo '<pre>';
+						print_r($response);
+						echo '</pre>';
+						exit();
+                    }
+                    else 
+                    {
+                        // failed request
+						debug_to_console( "Error response from server!" );
+						echo '<pre>';
+						print_r('HTTP Code: ' . $httpcode);
+						echo '</pre>';
+						echo '<pre>';
+                        echo 'Error response from the server!';
+						echo '</pre>';
+                        echo '<pre>';
+						print 'Error Code: '. $response->{'code'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Message: '. $response->{'message'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Information: '. $response->{'info'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Details: '. $response->{'detail'};
+						echo '</pre>';
+						echo '<pre>';
+						print_r($response);
+						echo '</pre>';
+						exit();
+					}
+        
+                }
+            }
+            
+        }
+		
+		// Catch and print any exceptions
+		catch (Exception $ex) {
+            debug_to_console( $ex );
+			print_r($ex);
+			exit();
+        }
+
+?>

--- a/php/ach/ach_get_charges.php
+++ b/php/ach/ach_get_charges.php
@@ -1,0 +1,147 @@
+<?php
+
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Sage Payment Solutions
+Contact: sdksupport@sage.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
+     
+    require("shared.php");
+    
+	// the nonce can be any unique identifier -- guids and timestamps work well
+	$nonce = uniqid();
+	
+	// a standard unix timestamp. a request must be received within 60s
+    // of its timestamp header.
+    $timestamp = (string)time();
+    
+	// Note that the verb here is differe from a Sale or Authorization. They use
+	// POST, with this request we will use GET.
+	$verb = "GET";
+	
+	// replace value after "reference=" with the transaction reference
+    $url = "https://api-cert.sagepayments.com/ach/v1/charges?reference=C61HCDL8b0";
+	
+	// You can also use other parameters with the request such as orderNumber. More
+	// details can be found at https://developer.sagepayments.com/ach/apis/get/charges
+	//$url = "https://api-cert.sagepayments.com/ach/v1/charges?orderNumber=Invoice%20624";
+	
+    // the request is authorized via an HMAC header that we generate by
+    // concatenating certain info, and then hashing it using our client key
+	// Note that there is no $payload. There is no request body when performing
+	// this type of request.
+	$toBeHashed = $verb . $url . $merchantCredentials["ID"] . $nonce . $timestamp;
+    $hmac = getHmac($toBeHashed, $developerCredentials["KEY"]);
+    
+    // ok, let's make the request! cURL is always an option, of course,
+    // but i find that file_get_contents is a bit more intuitive.
+	// Note there is no content header. Since there is no payload this is absent.
+	$config = [
+        "http" => [
+            "header" => [
+                "clientId: " . $developerCredentials["ID"],
+                "merchantId: " . $merchantCredentials["ID"],
+                "merchantKey: " . $merchantCredentials["KEY"],
+                "nonce: " . $nonce,
+                "timestamp: " . $timestamp,
+                "authorization: " . $hmac,
+                "content-type: application/json",
+            ],
+            "method" => $verb,
+            "ignore_errors" => true // exposes response body on 4XX errors
+        ]
+    ];
+    
+	// Process request and perform error checking.
+	try {
+              $context = stream_context_create($config);
+			  $result = file_get_contents($url, false, $context);
+              $response = json_decode($result);
+			  $httpcode = http_response_code();
+
+			  
+			// file_get_contents will return a true or false based on the success or failure of the connection  
+            if($result == FALSE) 
+            { 
+                debug_to_console( "file_get_contents: False" );
+				echo '<pre>';
+				print_r('HTTP Code: ' . $httpcode);
+				echo '</pre>';
+				echo '<pre>';
+				echo 'Error: Failed to read page'; 
+				echo '</pre>';
+				exit();
+			} 
+            else 
+            {
+                // check to see if the results are empty
+				if (empty($result)){
+					debug_to_console( "Error: Empty Result" );
+					echo '<pre>';
+					print_r('HTTP Code: ' . $httpcode);
+					echo '</pre>';
+					echo '<pre>';
+                    echo 'Error Empty Result';
+					echo '</pre>';
+                    print_r(json_encode($result));
+					exit();
+                }
+                else 
+                {
+                    // If the "status" key is present then the transaction either approved or declined. Otherwise
+					// the result will contain a code with an error
+					if(array_key_exists('startDate', $response)) 
+                    {
+                        // Successful request
+						debug_to_console( "file_get_contents: True" );
+						echo '<pre>';
+						print_r('HTTP Code: ' . $httpcode);
+						echo '</pre>';
+						echo '<pre>';
+                        echo 'Request Successfully Submitted';
+						echo '</pre>';
+					}
+                    else 
+                    {
+                        // failed request
+						debug_to_console( "Error response from server!" );
+						echo '<pre>';
+						print_r('HTTP Code: ' . $httpcode);
+						echo '</pre>';
+						echo '<pre>';
+                        echo 'Error response from the server!';
+						echo '</pre>';
+                        echo '<pre>';
+						print 'Error Code: '. $response->{'code'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Message: '. $response->{'message'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Information: '. $response->{'info'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Details: '. $response->{'detail'};
+						echo '</pre>';
+					}
+        
+                    // print the results
+					echo '<pre>';
+                    print_r($response);
+                    echo '</pre>';
+                }
+            }
+            
+        }
+		
+		// Catch and print any exceptions
+		catch (Exception $ex) {
+            debug_to_console( $ex );
+			print_r($ex);
+			exit();
+        }
+?>

--- a/php/ach/ach_get_charges_detail.php
+++ b/php/ach/ach_get_charges_detail.php
@@ -1,0 +1,143 @@
+<?php
+
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Sage Payment Solutions
+Contact: sdksupport@sage.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
+    
+    require("shared.php");
+    
+	// the nonce can be any unique identifier -- guids and timestamps work well
+	$nonce = uniqid();
+    
+	// a standard unix timestamp. a request must be received within 60s
+    // of its timestamp header.
+    $timestamp = (string)time();
+    
+	// Note that the verb here is differe from a Sale or Authorization. They use
+	// POST, with this request we will use GET.
+	$verb = "GET";
+	
+	// replace value after "charges/" with the transaction reference
+    $url = "https://api-cert.sagepayments.com/ach/v1/charges/C61HCDL8b0";
+    
+	// the request is authorized via an HMAC header that we generate by
+    // concatenating certain info, and then hashing it using our client key
+	// Note that there is no $payload. There is no request body when performing
+	// this type of request.
+	$toBeHashed = $verb . $url . $merchantCredentials["ID"] . $nonce . $timestamp;
+    $hmac = getHmac($toBeHashed, $developerCredentials["KEY"]);
+    
+    // ok, let's make the request! cURL is always an option, of course,
+    // but i find that file_get_contents is a bit more intuitive.
+	// Note there is no content header. Since there is no payload this is absent.
+	$config = [
+        "http" => [
+            "header" => [
+                "clientId: " . $developerCredentials["ID"],
+                "merchantId: " . $merchantCredentials["ID"],
+                "merchantKey: " . $merchantCredentials["KEY"],
+                "nonce: " . $nonce,
+                "timestamp: " . $timestamp,
+                "authorization: " . $hmac,
+                "content-type: application/json",
+            ],
+            "method" => $verb,
+            "ignore_errors" => true // exposes response body on 4XX errors
+        ]
+    ];
+	
+	// Process request and perform error checking.
+	try {
+              $context = stream_context_create($config);
+			  $result = file_get_contents($url, false, $context);
+              $response = json_decode($result);
+			  $httpcode = http_response_code();
+
+			  
+			// file_get_contents will return a true or false based on the success or failure of the connection  
+            if($result == FALSE) 
+            { 
+                debug_to_console( "file_get_contents: False" );
+				echo '<pre>';
+				print_r('HTTP Code: ' . $httpcode);
+				echo '</pre>';
+				echo '<pre>';
+				echo 'Error: Failed to read page'; 
+				echo '</pre>';
+				exit();
+			} 
+            else 
+            {
+                // check to see if the results are empty
+				if (empty($result)){
+					debug_to_console( "Error: Empty Result" );
+					echo '<pre>';
+					print_r('HTTP Code: ' . $httpcode);
+					echo '</pre>';
+					echo '<pre>';
+                    echo 'Error Empty Result';
+					echo '</pre>';
+                    print_r(json_encode($result));
+					exit();
+                }
+                else 
+                {
+                    // If the "status" key is present then the transaction either approved or declined. Otherwise
+					// the result will contain a code with an error
+					if(array_key_exists('startDate', $response)) 
+                    {
+                        // Successful request
+						debug_to_console( "file_get_contents: True" );
+						echo '<pre>';
+						print_r('HTTP Code: ' . $httpcode);
+						echo '</pre>';
+						echo '<pre>';
+                        echo 'Request Successfully Submitted';
+						echo '</pre>';
+					}
+                    else 
+                    {
+                        // failed request
+						debug_to_console( "Error response from server!" );
+						echo '<pre>';
+						print_r('HTTP Code: ' . $httpcode);
+						echo '</pre>';
+						echo '<pre>';
+                        echo 'Error response from the server!';
+						echo '</pre>';
+                        echo '<pre>';
+						print 'Error Code: '. $response->{'code'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Message: '. $response->{'message'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Information: '. $response->{'info'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Details: '. $response->{'detail'};
+						echo '</pre>';
+					}
+        
+                    // print the results
+					echo '<pre>';
+                    print_r($response);
+                    echo '</pre>';
+                }
+            }
+            
+        }
+		
+		// Catch and print any exceptions
+		catch (Exception $ex) {
+            debug_to_console( $ex );
+			print_r($ex);
+			exit();
+        }
+?>

--- a/php/ach/ach_sale.php
+++ b/php/ach/ach_sale.php
@@ -1,0 +1,201 @@
+<?php
+
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Sage Payment Solutions
+Contact: sdksupport@sage.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
+    
+    require("shared.php");
+	
+    // the nonce can be any unique identifier -- guids and timestamps work well
+    $nonce = uniqid();
+    
+    // a standard unix timestamp. a request must be received within 60s
+    // of its timestamp header.
+    $timestamp = (string)time();
+    
+    // setting up the request data itself
+    $verb = "POST";
+    $url = "https://api-cert.sagepayments.com/ach/v1/charges";
+	$requestData = [
+        // this is a pretty minimalistic example...
+        // complete reference material is available on the dev portal.
+		// at https://developer.sagepayments.com/ach/apis
+        "orderNumber" => "Invoice " . rand(0, 1000),
+		"secCode" => "PPD",
+        "amounts" => [
+			"total" => "10.01"
+        ],
+        "account" => [
+			"type" => "Checking", 
+            "routingNumber" => "056008849",
+			"accountNumber" => "12345678901234"
+        ],
+		"billing" => [
+			"name" => [
+				"first" => "John", 
+				"middle" => "",
+				"last" => "Simpson",
+				"suffix" => "Dr."
+			], 
+            "address" => "123 Main St",
+			"city" => "Savannah",
+			"state" => "GA",
+			"postalCode" => "31405",
+			"country" => "US"
+        ],
+		"addenda" => "Widgets",
+		"isRecurring" => false,
+		"vault" => [
+			"operation" => "Create"
+        ],
+		"memo" => "Test ACH Sale in Dev Portal"
+    ];
+    // convert to json for transport
+    $payload = json_encode($requestData);
+	
+    // the request is authorized via an HMAC header that we generate by
+    // concatenating certain info, and then hashing it using our client key
+    $toBeHashed = $verb . $url . $payload . $merchantCredentials["ID"] . $nonce . $timestamp;
+    $hmac = getHmac($toBeHashed, $developerCredentials["KEY"]);
+	
+    // ok, let's make the request! cURL is always an option, of course,
+    // but i find that file_get_contents is a bit more intuitive.
+    $config = [
+        "http" => [
+            "header" => [
+                "clientId: " . $developerCredentials["ID"],
+                "merchantId: " . $merchantCredentials["ID"],
+                "merchantKey: " . $merchantCredentials["KEY"],
+                "nonce: " . $nonce,
+                "timestamp: " . $timestamp,
+                "authorization: " . $hmac,
+                "content-type: application/json",
+            ],
+            "method" => $verb,
+            "content" => $payload,
+            "ignore_errors" => true // exposes response body on 4XX errors
+        ]
+    ];
+    
+	
+	// Process request and perform error checking.
+	try {
+              $context = stream_context_create($config);
+			  $result = file_get_contents($url, false, $context);
+              $response = json_decode($result);
+			  $httpcode = http_response_code();
+
+			  
+			// file_get_contents will return a true or false based on the success or failure of the connection  
+            if($result == FALSE) 
+            { 
+                debug_to_console( "file_get_contents: False" );
+				echo '<pre>';
+				print_r('HTTP Code: ' . $httpcode);
+				echo '</pre>';
+				echo '<pre>';
+				echo 'Error: Failed to read page'; 
+				echo '</pre>';
+				exit();
+			} 
+            else 
+            {
+                // check to see if the results are empty
+				if (empty($result)){
+					debug_to_console( "Error: Empty Result" );
+					echo '<pre>';
+					print_r('HTTP Code: ' . $httpcode);
+					echo '</pre>';
+					echo '<pre>';
+                    echo 'Error Empty Result';
+					echo '</pre>';
+                    print_r(json_encode($result));
+					exit();
+                }
+                else 
+                {
+                    // If the "status" key is present then the transaction either approved or declined. Otherwise
+					// the result will contain a code with an error
+					if(array_key_exists('status', $response)) 
+                    {
+                        // Successful request
+						debug_to_console( "file_get_contents: True" );
+						echo '<pre>';
+						print_r('HTTP Code: ' . $httpcode);
+						echo '</pre>';
+						echo '<pre>';
+                        echo 'Request Successfully Submitted';
+						echo '</pre>';
+						echo '<pre>';
+						print 'Status: '. $response->{'status'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Reference: '. $response->{'reference'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Message: '. $response->{'message'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Order Number: '. $response->{'orderNumber'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Vault Response Status: '. $response->{'vaultResponse'}->{'status'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Vault Response Message: '. $response->{'vaultResponse'}->{'message'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Vault Token: '. $response->{'vaultResponse'}->{'data'};
+						echo '</pre>';
+						echo '<pre>';
+						print_r($response);
+						echo '</pre>';
+						exit();
+                    }
+                    else 
+                    {
+                        // failed request
+						debug_to_console( "Error response from server!" );
+						echo '<pre>';
+						print_r('HTTP Code: ' . $httpcode);
+						echo '</pre>';
+						echo '<pre>';
+                        echo 'Error response from the server!';
+						echo '</pre>';
+                        echo '<pre>';
+						print 'Error Code: '. $response->{'code'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Message: '. $response->{'message'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Information: '. $response->{'info'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Details: '. $response->{'detail'};
+						echo '</pre>';
+						echo '<pre>';
+						print_r($response);
+						echo '</pre>';
+						exit();
+					}
+        
+                }
+            }
+            
+        }
+		
+		// Catch and print any exceptions
+		catch (Exception $ex) {
+            debug_to_console( $ex );
+			print_r($ex);
+			exit();
+        }
+
+?>

--- a/php/ach/ach_void.php
+++ b/php/ach/ach_void.php
@@ -1,0 +1,299 @@
+<?php
+ 
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Sage Payment Solutions
+Contact: sdksupport@sage.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
+   
+    require("shared.php");
+    // First we'll run a sale to give us something to void.
+	
+	// the nonce can be any unique identifier -- guids and timestamps work well
+    $nonce = uniqid();
+    
+	// a standard unix timestamp. a request must be received within 60s
+    // of its timestamp header.
+    $timestamp = (string)time();
+	
+	// setting up the request data itself
+    $verb = "POST";
+    $url = "https://api-cert.sagepayments.com/ach/v1/charges";
+    
+	// this is a pretty minimalistic example...
+	// complete reference material is available on the dev portal.
+	// at https://developer.sagepayments.com/ach/apis
+	$requestData = [
+		"orderNumber" => "Invoice " . rand(0, 1000),
+		"secCode" => "PPD",
+		"amounts" => [
+			"total" => "10.00"
+		],
+		"account" => [
+			"type" => "Checking", 
+			"routingNumber" => "056008849",
+			"accountNumber" => "12345678901234"
+		],
+		"billing" => [
+			"name" => [
+				"first" => "John", 
+				"middle" => "",
+				"last" => "Simpson",
+				"suffix" => "Dr."
+			], 
+			"address" => "123 Main St",
+			"city" => "Savannah",
+			"state" => "GA",
+			"postalCode" => "31405",
+			"country" => "US"
+		],
+		"addenda" => "Widgets",
+		"isRecurring" => false,
+		"vault" => [
+			"operation" => "Create"
+		],
+		"memo" => "Test ACH Sale in Dev Portal"
+    ];
+    
+	// convert to json for transport
+    $payload = json_encode($requestData);
+    
+    
+    // the request is authorized via an HMAC header that we generate by
+    // concatenating certain info, and then hashing it using our client key
+    $toBeHashed = $verb . $url . $payload . $merchantCredentials["ID"] . $nonce . $timestamp;
+    $hmac = getHmac($toBeHashed, $developerCredentials["KEY"]);
+    
+    // ok, let's make the request! cURL is always an option, of course,
+    // but i find that file_get_contents is a bit more intuitive.
+    $config = [
+        "http" => [
+            "header" => [
+                "clientId: " . $developerCredentials["ID"],
+                "merchantId: " . $merchantCredentials["ID"],
+                "merchantKey: " . $merchantCredentials["KEY"],
+                "nonce: " . $nonce,
+                "timestamp: " . $timestamp,
+                "authorization: " . $hmac,
+                "content-type: application/json",
+            ],
+            "method" => $verb,
+            "content" => $payload,
+            "ignore_errors" => true // exposes response body on 4XX errors
+        ]
+    ];
+	
+    // Process request and perform error checking.
+	try {
+              $context = stream_context_create($config);
+			  $result = file_get_contents($url, false, $context);
+              $response = json_decode($result);
+			  $httpcode = http_response_code();
+
+			  
+			// file_get_contents will return a true or false based on the success or failure of the connection  
+            if($result == FALSE) 
+            { 
+                debug_to_console( "file_get_contents: False" );
+				echo '<pre>';
+				print_r('HTTP Code: ' . $httpcode);
+				echo '</pre>';
+				echo '<pre>';
+				echo 'Error: Failed to read page'; 
+				echo '</pre>';
+				exit();
+			} 
+            else 
+            {
+                // check to see if the results are empty
+				if (empty($result)){
+					debug_to_console( "Error: Empty Result" );
+					echo '<pre>';
+					print_r('HTTP Code: ' . $httpcode);
+					echo '</pre>';
+					echo '<pre>';
+                    echo 'Error Empty Result';
+					echo '</pre>';
+                    print_r(json_encode($result));
+					exit();
+                }
+                else 
+                {
+                    // If the "status" key is present then the transaction either approved or declined. Otherwise
+					// the result will contain a code with an error
+					if(array_key_exists('status', $response)) 
+                    {
+                        // Successful request
+						debug_to_console( "file_get_contents: True" );
+						echo '<pre>';
+						print_r('HTTP Code: ' . $httpcode);
+						echo '</pre>';
+						echo '<pre>';
+                        echo 'Request Successfully Submitted';
+						echo '</pre>';
+						echo '<pre>';
+						print 'Status: '. $response->{'status'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Reference: '. $response->{'reference'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Message: '. $response->{'message'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Order Number: '. $response->{'orderNumber'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Vault Response Status: '. $response->{'vaultResponse'}->{'status'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Vault Response Message: '. $response->{'vaultResponse'}->{'message'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Vault Token: '. $response->{'vaultResponse'}->{'data'};
+						echo '</pre>';
+						echo '<pre>';
+						print_r($response);
+						echo '</pre>';
+                    }
+                    else 
+                    {
+                        // failed request
+						debug_to_console( "Error response from server!" );
+						echo '<pre>';
+						print_r('HTTP Code: ' . $httpcode);
+						echo '</pre>';
+						echo '<pre>';
+                        echo 'Error response from the server!';
+						echo '</pre>';
+                        echo '<pre>';
+						print 'Error Code: '. $response->{'code'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Message: '. $response->{'message'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Information: '. $response->{'info'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Details: '. $response->{'detail'};
+						echo '</pre>';
+						echo '<pre>';
+						print_r($response);
+						echo '</pre>';
+						exit();
+					}
+        
+                    // print the results
+					
+                }
+            }
+            
+        }
+		
+		// Catch and print any exceptions
+		catch (Exception $ex) {
+            debug_to_console( $ex );
+			print_r($ex);
+			exit();
+        }
+    
+    // ---------------------------------------------------------------
+    
+    // so, now we should have an approved charge -- what if we need to cancel it? 
+    // if it's still in our open batch (which usually = it's the same day), we 
+    // can void it out. if it's already been settled, we have to credit it.
+    // we'll need a new nonce and timestamp:
+    $nonce = uniqid();
+    $timestamp = (string)time();
+    
+    // we dont need a request body for this one
+    $payload = "";
+    // if you're familiar wtih RESTful APIs, you might have guessed this part:
+    // we're going to make a DELETE request to update the previous transaction.
+    $verb = "DELETE";
+    $url = "https://api-cert.sagepayments.com/ach/v1/charges/" . $response->reference;
+    // and then hmac...
+    $toBeHashed = $verb . $url . $payload . $merchantCredentials["ID"] . $nonce . $timestamp;
+    $hmac = getHmac($toBeHashed, $developerCredentials["KEY"]);
+    
+    // ... and submit!
+    
+    $config = [
+        "http" => [
+            "header" => [
+                "clientId: " . $developerCredentials["ID"],
+                "merchantId: " . $merchantCredentials["ID"],
+                "merchantKey: " . $merchantCredentials["KEY"],
+                "nonce: " . $nonce,
+                "timestamp: " . $timestamp,
+                "authorization: " . $hmac,
+                "content-type: application/json",
+            ],
+            "method" => $verb,
+            "ignore_errors" => true // exposes response body on 4XX errors
+        ]
+    ];
+    
+	// Process request and perform error checking.
+	try {
+              $context = stream_context_create($config);
+			  $result = file_get_contents($url, false, $context);
+              $response = json_decode($result);
+			  $httpcode = http_response_code();
+
+			  
+			// file_get_contents will return a true or false based on the success or failure of the connection  
+            if($httpcode == 200) 
+				{
+					// Successful request
+					debug_to_console( "file_get_contents: True" );
+					echo '<pre>';
+					print_r('HTTP Code: ' . $httpcode);
+					echo '</pre>';
+					echo '<pre>';
+					print 'Request Successfully Voided';
+					echo '</pre>';
+				}
+				else 
+				{
+					// failed request
+					debug_to_console( "Error response from server!" );
+					echo '<pre>';
+					print_r('HTTP Code: ' . $httpcode);
+					echo '</pre>';
+					echo '<pre>';
+					echo 'Error response from the server!';
+					echo '</pre>';
+					echo '<pre>';
+					print 'Error Code: '. $response->{'code'};
+					echo '</pre>';
+					echo '<pre>';
+					print 'Error Message: '. $response->{'message'};
+					echo '</pre>';
+					echo '<pre>';
+					print 'Error Information: '. $response->{'info'};
+					echo '</pre>';
+					echo '<pre>';
+					print 'Error Details: '. $response->{'detail'};
+					echo '</pre>';
+					echo '<pre>';
+					print_r($response);
+					echo '</pre>';
+					exit();
+				}
+            
+            
+        }
+		
+		// Catch and print any exceptions
+		catch (Exception $ex) {
+            debug_to_console( $ex );
+			print_r($ex);
+			exit();
+        }
+?>

--- a/php/ach/ach_void_credit.php
+++ b/php/ach/ach_void_credit.php
@@ -1,0 +1,299 @@
+<?php
+ 
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Sage Payment Solutions
+Contact: sdksupport@sage.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
+   
+    require("shared.php");
+    // First we'll run a sale to give us something to void.
+	
+	// the nonce can be any unique identifier -- guids and timestamps work well
+    $nonce = uniqid();
+    
+	// a standard unix timestamp. a request must be received within 60s
+    // of its timestamp header.
+    $timestamp = (string)time();
+	
+	// setting up the request data itself
+    $verb = "POST";
+    $url = "https://api-cert.sagepayments.com/ach/v1/credits";
+    
+	// this is a pretty minimalistic example...
+	// complete reference material is available on the dev portal.
+	// at https://developer.sagepayments.com/ach/apis
+	$requestData = [
+		"orderNumber" => "Invoice " . rand(0, 1000),
+		"secCode" => "PPD",
+		"amounts" => [
+			"total" => "10.00"
+		],
+		"account" => [
+			"type" => "Checking", 
+			"routingNumber" => "056008849",
+			"accountNumber" => "12345678901234"
+		],
+		"billing" => [
+			"name" => [
+				"first" => "John", 
+				"middle" => "",
+				"last" => "Simpson",
+				"suffix" => "Dr."
+			], 
+			"address" => "123 Main St",
+			"city" => "Savannah",
+			"state" => "GA",
+			"postalCode" => "31405",
+			"country" => "US"
+		],
+		"addenda" => "Widgets",
+		"isRecurring" => false,
+		"vault" => [
+			"operation" => "Create"
+		],
+		"memo" => "Test ACH Credit in Dev Portal"
+    ];
+    
+	// convert to json for transport
+    $payload = json_encode($requestData);
+    
+    
+    // the request is authorized via an HMAC header that we generate by
+    // concatenating certain info, and then hashing it using our client key
+    $toBeHashed = $verb . $url . $payload . $merchantCredentials["ID"] . $nonce . $timestamp;
+    $hmac = getHmac($toBeHashed, $developerCredentials["KEY"]);
+    
+    // ok, let's make the request! cURL is always an option, of course,
+    // but i find that file_get_contents is a bit more intuitive.
+    $config = [
+        "http" => [
+            "header" => [
+                "clientId: " . $developerCredentials["ID"],
+                "merchantId: " . $merchantCredentials["ID"],
+                "merchantKey: " . $merchantCredentials["KEY"],
+                "nonce: " . $nonce,
+                "timestamp: " . $timestamp,
+                "authorization: " . $hmac,
+                "content-type: application/json",
+            ],
+            "method" => $verb,
+            "content" => $payload,
+            "ignore_errors" => true // exposes response body on 4XX errors
+        ]
+    ];
+	
+    // Process request and perform error checking.
+	try {
+              $context = stream_context_create($config);
+			  $result = file_get_contents($url, false, $context);
+              $response = json_decode($result);
+			  $httpcode = http_response_code();
+
+			  
+			// file_get_contents will return a true or false based on the success or failure of the connection  
+            if($result == FALSE) 
+            { 
+                debug_to_console( "file_get_contents: False" );
+				echo '<pre>';
+				print_r('HTTP Code: ' . $httpcode);
+				echo '</pre>';
+				echo '<pre>';
+				echo 'Error: Failed to read page'; 
+				echo '</pre>';
+				exit();
+			} 
+            else 
+            {
+                // check to see if the results are empty
+				if (empty($result)){
+					debug_to_console( "Error: Empty Result" );
+					echo '<pre>';
+					print_r('HTTP Code: ' . $httpcode);
+					echo '</pre>';
+					echo '<pre>';
+                    echo 'Error Empty Result';
+					echo '</pre>';
+                    print_r(json_encode($result));
+					exit();
+                }
+                else 
+                {
+                    // If the "status" key is present then the transaction either approved or declined. Otherwise
+					// the result will contain a code with an error
+					if(array_key_exists('status', $response)) 
+                    {
+                        // Successful request
+						debug_to_console( "file_get_contents: True" );
+						echo '<pre>';
+						print_r('HTTP Code: ' . $httpcode);
+						echo '</pre>';
+						echo '<pre>';
+                        echo 'Request Successfully Submitted';
+						echo '</pre>';
+						echo '<pre>';
+						print 'Status: '. $response->{'status'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Reference: '. $response->{'reference'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Message: '. $response->{'message'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Order Number: '. $response->{'orderNumber'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Vault Response Status: '. $response->{'vaultResponse'}->{'status'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Vault Response Message: '. $response->{'vaultResponse'}->{'message'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Vault Token: '. $response->{'vaultResponse'}->{'data'};
+						echo '</pre>';
+						echo '<pre>';
+						print_r($response);
+						echo '</pre>';
+                    }
+                    else 
+                    {
+                        // failed request
+						debug_to_console( "Error response from server!" );
+						echo '<pre>';
+						print_r('HTTP Code: ' . $httpcode);
+						echo '</pre>';
+						echo '<pre>';
+                        echo 'Error response from the server!';
+						echo '</pre>';
+                        echo '<pre>';
+						print 'Error Code: '. $response->{'code'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Message: '. $response->{'message'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Information: '. $response->{'info'};
+						echo '</pre>';
+						echo '<pre>';
+						print 'Error Details: '. $response->{'detail'};
+						echo '</pre>';
+						echo '<pre>';
+						print_r($response);
+						echo '</pre>';
+						exit();
+					}
+        
+                    // print the results
+					
+                }
+            }
+            
+        }
+		
+		// Catch and print any exceptions
+		catch (Exception $ex) {
+            debug_to_console( $ex );
+			print_r($ex);
+			exit();
+        }
+    
+    // ---------------------------------------------------------------
+    
+    // so, now we should have an approved charge -- what if we need to cancel it? 
+    // if it's still in our open batch (which usually = it's the same day), we 
+    // can void it out. if it's already been settled, we have to credit it.
+    // we'll need a new nonce and timestamp:
+    $nonce = uniqid();
+    $timestamp = (string)time();
+    
+    // we dont need a request body for this one
+    $payload = "";
+    // if you're familiar wtih RESTful APIs, you might have guessed this part:
+    // we're going to make a DELETE request to update the previous transaction.
+    $verb = "DELETE";
+    $url = "https://api-cert.sagepayments.com/ach/v1/credits/" . $response->reference;
+    // and then hmac...
+    $toBeHashed = $verb . $url . $payload . $merchantCredentials["ID"] . $nonce . $timestamp;
+    $hmac = getHmac($toBeHashed, $developerCredentials["KEY"]);
+    
+    // ... and submit!
+    
+    $config = [
+        "http" => [
+            "header" => [
+                "clientId: " . $developerCredentials["ID"],
+                "merchantId: " . $merchantCredentials["ID"],
+                "merchantKey: " . $merchantCredentials["KEY"],
+                "nonce: " . $nonce,
+                "timestamp: " . $timestamp,
+                "authorization: " . $hmac,
+                "content-type: application/json",
+            ],
+            "method" => $verb,
+            "ignore_errors" => true // exposes response body on 4XX errors
+        ]
+    ];
+    
+	// Process request and perform error checking.
+	try {
+              $context = stream_context_create($config);
+			  $result = file_get_contents($url, false, $context);
+              $response = json_decode($result);
+			  $httpcode = http_response_code();
+
+			  
+			// file_get_contents will return a true or false based on the success or failure of the connection  
+            if($httpcode == 200) 
+				{
+					// Successful request
+					debug_to_console( "file_get_contents: True" );
+					echo '<pre>';
+					print_r('HTTP Code: ' . $httpcode);
+					echo '</pre>';
+					echo '<pre>';
+					print 'Request Successfully Voided';
+					echo '</pre>';
+				}
+				else 
+				{
+					// failed request
+					debug_to_console( "Error response from server!" );
+					echo '<pre>';
+					print_r('HTTP Code: ' . $httpcode);
+					echo '</pre>';
+					echo '<pre>';
+					echo 'Error response from the server!';
+					echo '</pre>';
+					echo '<pre>';
+					print 'Error Code: '. $response->{'code'};
+					echo '</pre>';
+					echo '<pre>';
+					print 'Error Message: '. $response->{'message'};
+					echo '</pre>';
+					echo '<pre>';
+					print 'Error Information: '. $response->{'info'};
+					echo '</pre>';
+					echo '<pre>';
+					print 'Error Details: '. $response->{'detail'};
+					echo '</pre>';
+					echo '<pre>';
+					print_r($response);
+					echo '</pre>';
+					exit();
+				}
+            
+            
+        }
+		
+		// Catch and print any exceptions
+		catch (Exception $ex) {
+            debug_to_console( $ex );
+			print_r($ex);
+			exit();
+        }
+?>

--- a/php/ach/shared.php
+++ b/php/ach/shared.php
@@ -1,0 +1,60 @@
+<?php
+
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Sage Payment Solutions
+Contact: sdksupport@sage.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
+
+    // You (or your client's) merchant credentials.
+    // grab a test account from us for development!
+	// If you would like a merchant test account, please
+	// email us at sdksupport@sage.com, otherwise
+	// you are welcome to test with the credentials below.
+    $merchantCredentials = [
+       "ID" => "173859436515",
+       "KEY" => "P1J2V8P2Q3D8"
+    ];
+    
+	// Your application's credentials. In order to obtain
+	// your individual developer credentials you must
+	// register with the developer portal at https://developer.sagepayments.com
+	// and setup an app under "My Apps".
+    $developerCredentials = [
+       "ID" => "W8yvKQ5XbvAn7dUDJeAnaWCEwA4yXEgd",
+       "KEY" => "iLzODV5AUsCGWGkr"
+    ];
+
+	
+	function getHmac($toBeHashed, $privateKey){
+       
+        $hmac = hash_hmac(
+            "sha512", // use the SHA-512 algorithm...
+            $toBeHashed, // ... to hash the combined string...
+            $privateKey, // .. using your private dev key to sign it.
+            true // (php returns hexits by default; override this)
+        );
+        // convert to base-64 for transport
+        $hmac_b64 = base64_encode($hmac);
+        return $hmac_b64;
+    }
+	
+	// This function allows you to easily print data to the console
+	// for debugging. 
+	// !!!!!!!!!!!!!!!!!!!!!!!!  IMPORTANT NOTE  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+	// Please make sure you are not printing PCI-
+	// sensitive data to the console when moving to production.
+	// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+	function debug_to_console( $data ) {
+		$output = $data;
+		if ( is_array( $output ) )
+			$output = implode( ',', $output);
+
+		echo "<script>console.log( 'Debug Objects: " . $output . "' );</script>";
+	}
+	
+?>


### PR DESCRIPTION
adding ACH samples to Direct API repository
- added ach functions for sale, credit, void, void_credit, get_charges,
get_charges_detail
- added enhanced response filtering logic to display result details,
will be adding this to Bankcard transactions soon.
- added console logging function to shared.php to make debugging easier.
- added comments for new functionality and to note that these samples
are intended for educational use only and not for production.