### PR TITLE
Updated comments to Paya and TLS 1.0 Decommission

### DIFF
--- a/csharp/DirectAPI_Csharp_Sample/DirectAPI_Csharp_Sample/Form1.cs
+++ b/csharp/DirectAPI_Csharp_Sample/DirectAPI_Csharp_Sample/Form1.cs
@@ -5,17 +5,24 @@ using System.Security.Cryptography;
 using System.Net;
 using System.IO;
 
+
+
+
 namespace DirectAPI_Csharp_Sample
 {
     //=====================================================
     //Sample Direct API request - C#.net
     //Thomas Hagan
-    //Integration Consultant
-    //Sage Payment Solutions
-    //November 22nd, 2016
+    //Integration Consultant Sr
+    //Paya, Inc.
+    //Pubilished: November 22nd, 2016
+    //Updated: October 3rd, 2018 - Removed references to "Sage" 
+    //  other than existing sagepayments URLs. Also addressed TLS
+    //  1.0 shutdown issues.
+    //
     //Application is intended for instructional use only.
     //If you have any questions, please feel free to email
-    //the Integration Support team at sdksupport@sage.com
+    //the Integration Support team at sdksupport@paya.com
     //Also, please make sure to register for API credentials
     //at our developer portal: https://developer.sagepayments.com
     //======================================================
@@ -29,7 +36,7 @@ namespace DirectAPI_Csharp_Sample
         private void btProcess_Click(object sender, EventArgs e)
         {
             //TH - Test Data. This is the test account infomation we provide
-            //in the API Sandbox. Please contact us at sdksupport@sage.com if
+            //in the API Sandbox. Please contact us at sdksupport@paya.com if
             //you need a unique test account and receive the Merchant ID and
             //Merchant Key. In order to get your own Client ID and Client Secret
             //you must register at https://developer.sagepayments.com and setup
@@ -88,12 +95,18 @@ namespace DirectAPI_Csharp_Sample
             byte[] hash_authToken = new HMACSHA512(Encoding.ASCII.GetBytes(clientSecret)).ComputeHash(Encoding.ASCII.GetBytes(authToken));
             string hash64_authToken = Convert.ToBase64String(hash_authToken);
 
+            //////////////////////////////////////////////////////////////////
+            //TH - 20181003 - Added for TLS 1.0 shutdown requirements.
+            ServicePointManager.Expect100Continue = true;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+            //////////////////////////////////////////////////////////////////
+
             //TH - Initiate Web Request
             var web_request = (HttpWebRequest)WebRequest.Create(url_sale);
 
             //TH - Set the headers and details
             var web_request_headers = web_request.Headers;
-            Console.WriteLine("Configuring web_request to include headers for Sage Direct API");
+            Console.WriteLine("Configuring web_request to include headers for Paya Direct API");
             web_request_headers["clientId"] = clientId;
             web_request_headers["merchantId"] = merchantId;
             web_request_headers["merchantKey"] = merchantKey;
@@ -106,6 +119,7 @@ namespace DirectAPI_Csharp_Sample
             var byteArray = Encoding.ASCII.GetBytes(strRequest);
 
             //TH - Send the data
+
             web_request.ContentType = contentType;
             web_request.ContentLength = byteArray.Length;
             var datastream = web_request.GetRequestStream();

--- a/php/account_updater/get_account_updater.php
+++ b/php/account_updater/get_account_updater.php
@@ -1,13 +1,12 @@
 <?php
-
 /*----------------------------------------------
 Author: SDK Support Group
-Company: Sage Payment Solutions
-Contact: sdksupport@sage.com
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! Samples intended for educational use only!!!
-!!!        Not intended for production       !!!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 -----------------------------------------------*/
      
     require("shared.php");

--- a/php/account_updater/shared.php
+++ b/php/account_updater/shared.php
@@ -1,19 +1,18 @@
 <?php
-
 /*----------------------------------------------
 Author: SDK Support Group
-Company: Sage Payment Solutions
-Contact: sdksupport@sage.com
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! Samples intended for educational use only!!!
-!!!        Not intended for production       !!!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 -----------------------------------------------*/
 
     // You (or your client's) merchant credentials.
     // grab a test account from us for development!
 	// If you would like a merchant test account, please
-	// email us at sdksupport@sage.com, otherwise
+	// email us at sdksupport@paya.com, otherwise
 	// you are welcome to test with the credentials below.
     $merchantCredentials = [
        "ID" => "173859436515",

--- a/php/ach/ach_credit.php
+++ b/php/ach/ach_credit.php
@@ -1,13 +1,12 @@
 <?php
-
 /*----------------------------------------------
 Author: SDK Support Group
-Company: Sage Payment Solutions
-Contact: sdksupport@sage.com
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! Samples intended for educational use only!!!
-!!!        Not intended for production       !!!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 -----------------------------------------------*/
     
     require("shared.php");

--- a/php/ach/ach_get_charges.php
+++ b/php/ach/ach_get_charges.php
@@ -1,13 +1,12 @@
 <?php
-
 /*----------------------------------------------
 Author: SDK Support Group
-Company: Sage Payment Solutions
-Contact: sdksupport@sage.com
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! Samples intended for educational use only!!!
-!!!        Not intended for production       !!!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 -----------------------------------------------*/
      
     require("shared.php");

--- a/php/ach/ach_get_charges_detail.php
+++ b/php/ach/ach_get_charges_detail.php
@@ -1,13 +1,12 @@
 <?php
-
 /*----------------------------------------------
 Author: SDK Support Group
-Company: Sage Payment Solutions
-Contact: sdksupport@sage.com
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! Samples intended for educational use only!!!
-!!!        Not intended for production       !!!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 -----------------------------------------------*/
     
     require("shared.php");

--- a/php/ach/ach_sale.php
+++ b/php/ach/ach_sale.php
@@ -1,13 +1,12 @@
 <?php
-
 /*----------------------------------------------
 Author: SDK Support Group
-Company: Sage Payment Solutions
-Contact: sdksupport@sage.com
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! Samples intended for educational use only!!!
-!!!        Not intended for production       !!!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 -----------------------------------------------*/
     
     require("shared.php");

--- a/php/ach/ach_void.php
+++ b/php/ach/ach_void.php
@@ -1,13 +1,12 @@
 <?php
- 
 /*----------------------------------------------
 Author: SDK Support Group
-Company: Sage Payment Solutions
-Contact: sdksupport@sage.com
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! Samples intended for educational use only!!!
-!!!        Not intended for production       !!!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 -----------------------------------------------*/
    
     require("shared.php");

--- a/php/ach/ach_void_credit.php
+++ b/php/ach/ach_void_credit.php
@@ -1,13 +1,12 @@
 <?php
- 
 /*----------------------------------------------
 Author: SDK Support Group
-Company: Sage Payment Solutions
-Contact: sdksupport@sage.com
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! Samples intended for educational use only!!!
-!!!        Not intended for production       !!!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 -----------------------------------------------*/
    
     require("shared.php");

--- a/php/ach/shared.php
+++ b/php/ach/shared.php
@@ -1,19 +1,18 @@
 <?php
-
 /*----------------------------------------------
 Author: SDK Support Group
-Company: Sage Payment Solutions
-Contact: sdksupport@sage.com
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !!! Samples intended for educational use only!!!
-!!!        Not intended for production       !!!!!!!!!!!
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 -----------------------------------------------*/
 
     // You (or your client's) merchant credentials.
     // grab a test account from us for development!
 	// If you would like a merchant test account, please
-	// email us at sdksupport@sage.com, otherwise
+	// email us at sdksupport@paya.com, otherwise
 	// you are welcome to test with the credentials below.
     $merchantCredentials = [
        "ID" => "173859436515",

--- a/php/authAndCap.php
+++ b/php/authAndCap.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
     
     require("shared.php");
 

--- a/php/credit.php
+++ b/php/credit.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
     
     require("shared.php");
 

--- a/php/creditByReference.php
+++ b/php/creditByReference.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
     
     require("shared.php");
 

--- a/php/reportingByDate.php
+++ b/php/reportingByDate.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
     
     require("shared.php");
 

--- a/php/reportingDateAndTrxType.php
+++ b/php/reportingDateAndTrxType.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
     
     require("shared.php");
 

--- a/php/reportingNoDate.php
+++ b/php/reportingNoDate.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
     
     require("shared.php");
 

--- a/php/retailWithAVS.php
+++ b/php/retailWithAVS.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
     
     require("shared.php");
 

--- a/php/sale.php
+++ b/php/sale.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
     
     require("shared.php");
 

--- a/php/saleLevel2.php
+++ b/php/saleLevel2.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
     
     require("shared.php");
 

--- a/php/saleLevel3.php
+++ b/php/saleLevel3.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
     
     require("shared.php");
 

--- a/php/saleWithAVS.php
+++ b/php/saleWithAVS.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
     
     require("shared.php");
 

--- a/php/shared.php
+++ b/php/shared.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
 
 
     // you (or your client's) merchant credentials.

--- a/php/vault.php
+++ b/php/vault.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
     
     require("shared.php");
 

--- a/php/vaultDelete.php
+++ b/php/vaultDelete.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
     
     require("shared.php");
     $nonce = uniqid();

--- a/php/vaultSale.php
+++ b/php/vaultSale.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
     
     require("shared.php");
 

--- a/php/vaultUpdate.php
+++ b/php/vaultUpdate.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
     
     require("shared.php");
 

--- a/php/void.php
+++ b/php/void.php
@@ -1,4 +1,13 @@
 <?php
+/*----------------------------------------------
+Author: SDK Support Group
+Company: Paya
+Contact: sdksupport@paya.com
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! Samples intended for educational use only!!!
+!!!        Not intended for production       !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+-----------------------------------------------*/
     
     require("shared.php");
 

--- a/python/sale.py
+++ b/python/sale.py
@@ -1,9 +1,9 @@
 # Sample donated by Coretechs
-# Updated By: Thomas Hagan - Integration Consultant, Product Integration
-# Company: Sage Payment Solutions
+# Updated By: SDK Support, Tech Ops
+# Company: Paya, Inc.
 # Sample for educational use only - not intended for production.
 # If you have any questions regarding the sample or the Direct API please contact
-# us at sdksupport@sage.com
+# us at sdksupport@paya.com
 import uuid
 import hmac
 import hashlib
@@ -34,17 +34,17 @@ requests_log.propagate = True
 # These are the Merchant Credentials, please feel free to use the prodvided
 # Merchant ID and Merchant Key for testing. If you would like your own test 
 # Merchant account with access to the Virtual Terminal, please request an account
-# from sdksupport@sage.com
-SAGE_MERCHANT_ID = '173859436515'
-SAGE_MERCHANT_KEY = 'P1J2V8P2Q3D8'
+# from sdksupport@paya.com
+PAYA_MERCHANT_ID = '173859436515'
+PAYA_MERCHANT_KEY = 'P1J2V8P2Q3D8'
 # These are the Developer/API Credentials, please feel free to use the prodvided
 # Client ID and Client Secret for initial testing. However, once you register 
 # with the developer portal at https://developer.sagepayments.com you will need
 # to setup an App under "My Apps", this will provide your unique Client ID and 
 # Client Secret.
-SAGE_CLIENT_ID = 'W8yvKQ5XbvAn7dUDJeAnaWCEwA4yXEgd'
-SAGE_CLIENT_SECRET = b"iLzODV5AUsCGWGkr"
-SAGE_API_ENDPOINT = 'https://api-cert.sagepayments.com/'
+PAYA_CLIENT_ID = 'W8yvKQ5XbvAn7dUDJeAnaWCEwA4yXEgd'
+PAYA_CLIENT_SECRET = b"iLzODV5AUsCGWGkr"
+PAYA_API_ENDPOINT = 'https://api-cert.sagepayments.com/'
 
 
 # the nonce can be any unique identifier -- guids and timestamps work well
@@ -59,7 +59,7 @@ timestamp = int(time.time())
 verb = "POST"
 url = "https://api-cert.sagepayments.com/bankcard/v1/charges?type=Sale"
 # url = "http://requestb.in" # This is a great alternative URL for testing. Please
-# keep in mind Requestb.in is not managed by Sage Payment Solutions.
+# keep in mind Requestb.in is not managed by Paya, Inc.
 
 requestData = {
     # this is a pretty minimalistic example...
@@ -91,27 +91,27 @@ payload = json.dumps(requestData)
 
 # the request is authorized via an HMAC header that we generate by
 # concatenating certain info, and then hashing it using our client key
-toBeHashed = "{verb}{url}{payload}{SAGE_MERCHANT_ID}{nonce}{timestamp}".format(
+toBeHashed = "{verb}{url}{payload}{PAYA_MERCHANT_ID}{nonce}{timestamp}".format(
     verb=verb,
     url=url,
     payload=payload,
-    SAGE_MERCHANT_ID=SAGE_MERCHANT_ID,
+    PAYA_MERCHANT_ID=PAYA_MERCHANT_ID,
     nonce=nonce,
     timestamp=timestamp,
 )
 
 # build the authorization for the header. With python it is not necessary to
 # convert the hmac to hex prior to base64 encoding it.
-digest = hmac.new(SAGE_CLIENT_SECRET, msg=toBeHashed.encode('utf-8'), digestmod=hashlib.sha512).digest()
+digest = hmac.new(PAYA_CLIENT_SECRET, msg=toBeHashed.encode('utf-8'), digestmod=hashlib.sha512).digest()
 signature = base64.b64encode(digest).decode()
 
 # submit the POST with the appropriate headers.
 r = requests.post(
     url,
     headers={
-        'clientId': SAGE_CLIENT_ID,
-        'merchantId': SAGE_MERCHANT_ID,
-        'merchantKey': SAGE_MERCHANT_KEY,
+        'clientId': PAYA_CLIENT_ID,
+        'merchantId': PAYA_MERCHANT_ID,
+        'merchantKey': PAYA_MERCHANT_KEY,
         'nonce': str(nonce),
         'timestamp': str(timestamp),
         'authorization': signature,

--- a/vbnet/DirectAPI_VBnet_Sample/DirectAPI_VBnet_Sample/Form1.vb
+++ b/vbnet/DirectAPI_VBnet_Sample/DirectAPI_VBnet_Sample/Form1.vb
@@ -9,14 +9,18 @@ Imports System.IO
 Public Class Main
 
     '=====================================================
-    'Sample Direct API request - VB.net
+    'Sample Direct API request - C#.net
     'Thomas Hagan
-    'Integration Consultant
-    'Sage Payment Solutions
-    'October 24th, 2016
-    'Application is intended for instructional use only.
+    'Integration Consultant Sr
+    'Paya, Inc.
+    'Pubilished: November 22nd, 2016
+    'Updated: October 3rd, 2018 - Removed references to "Sage" 
+    '  other than existing sagepayments URLs. Also addressed TLS
+    '  1.0 shutdown issues.
+    '
+    'Application Is intended for instructional use only.
     'If you have any questions, please feel free to email
-    'the Integration Support team at sdksupport@sage.com
+    'the Integration Support team at sdksupport@paya.com
     'Also, please make sure to register for API credentials
     'at our developer portal: https://developer.sagepayments.com
     '======================================================
@@ -75,12 +79,18 @@ Public Class Main
         End Using
         hash64_authToken = Convert.ToBase64String(hash_authToken)
 
+        '//////////////////////////////////////////////////////////////////
+        'TH - 20181003 - Added for TLS 1.0 shutdown requirements.
+        ServicePointManager.Expect100Continue = True
+        ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12
+        '//////////////////////////////////////////////////////////////////
+
         'TH - Initiate a Web Request
         Dim web_request As HttpWebRequest = CType(HttpWebRequest.Create(url_sale), HttpWebRequest)
 
         'TH - Set the headers and details
         Dim web_request_headers As WebHeaderCollection = web_request.Headers
-        Console.WriteLine("Configuring web_request to included headers for Sage Direct API")
+        Console.WriteLine("Configuring web_request to included headers for Paya Direct API")
         web_request_headers.Add("clientId: " & clientId)
         web_request_headers.Add("merchantId: " & merchantId)
         web_request_headers.Add("merchantKey: " & merchantKey)
@@ -117,33 +127,33 @@ Public Class Main
 
             txtJSONResponse.Text = responseFromServer
 
-			'JG - Deserialize and work with reponse elements
-			 Dim exampleJson As String = responseFromServer
-			 Dim post = JsonConvert.DeserializeObject(exampleJson)
-             Dim status As String = post("status") ' Approval code 
-			 Dim reference As String = post("reference")
-             Dim message As String = post("message")
-             Dim code As String = post("code")
-             Dim cvvresult As String = post("cvvresult")
-             Dim avsresult As String = post("avsresult")
-             Dim riskcode As String = post("riskcode")
+            'JG - Deserialize and work with reponse elements
+            Dim exampleJson As String = responseFromServer
+            Dim post = JsonConvert.DeserializeObject(exampleJson)
+            Dim status As String = post("status") ' Approval code 
+            Dim reference As String = post("reference")
+            Dim message As String = post("message")
+            Dim code As String = post("code")
+            Dim cvvresult As String = post("cvvresult")
+            Dim avsresult As String = post("avsresult")
+            Dim riskcode As String = post("riskcode")
             'txtJSONResponse.text = txtJSONResponse.text & Deserialized element:" & status
-	
+
             'TH - Updated 20170303 - Added more detail to response display 'JG - Added Ctype structure as previous was not working in all instances.
             txtJSONResponse.Text = "Server Status Code: " & (CType(web_response, HttpWebResponse).StatusCode) & vbCrLf &
-                "Server Status: " & (CType(web_response, HttpWebResponse).Description) & vbCrLf &
+                "Server Status: " & (CType(web_response, HttpWebResponse).StatusDescription) & vbCrLf &
                 "API Response: " & responseFromServer
 
             'JG - Deserialize and work with reponse elements
             'TH - Updated 20170303 - changed the value of exampleJson to use responseFromServer as the
             'text object txtJSONResponse has non-JSON data.
-            Dim exampleJson As String = responseFromServer
-            Dim post = JsonConvert.DeserializeObject(exampleJson)
-            Dim status As String = post("status") ' Approval code 
-            txtJSONResponse.Text = responseFromServer & vbCrLf & vbCrLf & "Deserialized Element:" & status
-					
-			
-			
+            'Dim exampleJson As String = responseFromServer
+            'Dim post = JsonConvert.DeserializeObject(exampleJson)
+            'Dim status As String = post("status") ' Approval code 
+            'txtJSONResponse.Text = responseFromServer & vbCrLf & vbCrLf & "Deserialized Element:" & status
+
+
+
             'TH - Catch any errors.
             'TH - Updated 03/03/2017 - Added WebException and extra error gathering to include response stream.
         Catch ex As WebException
@@ -151,11 +161,13 @@ Public Class Main
             'Read the real response from the server
             Dim sResponse As String = New StreamReader(ex.Response.GetResponseStream()).ReadToEnd
 
-	txtJSONResponse.Text = "Web Exception Message: " & ex.Message.ToString & vbCrLf & vbCrLf &
-                "API Response: " & sResponse
+            txtJSONResponse.Text = "Web Exception Message: " & ex.Message.ToString & vbCrLf & vbCrLf &
+                        "API Response: " & sResponse
 
         Catch ex As Exception
             txtJSONResponse.Text = "Exception Message: " & ex.Message.ToString
+
+        End Try
 
 
     End Sub
@@ -163,7 +175,7 @@ Public Class Main
     Private Sub btLoad_Click(sender As Object, e As EventArgs) Handles btLoad.Click
 
         'TH - Test Data. This is the test account infomation we provide
-        'in the API Sandbox. Please contact us at sdksupport@sage.com if
+        'in the API Sandbox. Please contact us at sdksupport@paya.com if
         'you need a unique test account and receive the Merchant ID and
         'Merchant Key. In order to get your own Client ID and Client Secret
         'you must register at https://developer.sagepayments.com and setup


### PR DESCRIPTION
Updates:

- Updated all code and samples to replace any references to "Sage" or "Sage Payment Solutions" to "Paya" or "Paya, Inc.". This excludes the references to "sagepayments" URLs.
- Updated VB and C# samples to comply with TLS 1.2 requirements.